### PR TITLE
ENV Variable for SAML URL HOST

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -288,7 +288,7 @@ SAML_PROVIDERS = [{
         "debug": False,
         "custom_base_path": "",
         "sp": {
-            "entityId": "{0}/api/api-saml/sso/saml/metadata".foramt(os.getenv('SAML_HOST_BASE_URL')),
+            "entityId": "{0}/api/api-saml/sso/saml/metadata".format(os.getenv('SAML_HOST_BASE_URL')),
             "assertionConsumerService": {
                 "url": "{0}/api/api-saml/sso/saml/?acs".format(os.getenv('SAML_HOST_BASE_URL')),
                 "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"


### PR DESCRIPTION
Removed hard coded SAML Base URL within settings.py. This is now controled by SAML_HOST_BASE_URL environment variable. 