### PR TITLE
Counter upgrade - For Counter v2.0.0 RC1

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -61,7 +61,6 @@ class APIRoot(APIView):
             'Data Store': {
                 'Mongo': reverse('data-list', request=request),
                 'Counter': [ reverse('platform-list', request=request),
-                            reverse('publication-list',request=request),
                             reverse('filter-list', request=request),
                             reverse('title-list', request=request)],
                 'S3': [ reverse('buckets-list', request=request),

--- a/dockerfile
+++ b/dockerfile
@@ -16,6 +16,7 @@ RUN apk add mariadb-dev \
 RUN cp /usr/share/zoneinfo/America/Denver /etc/localtime
 # App requirements
 RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install python3-saml==1.11
 RUN rm requirements.txt
 RUN mkdir -p /data/file_upload
 RUN chmod -R 777 /data/file_upload

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ boto3
 requests
 arkpy
 #vine==1.3.0
+drf-renderer-xlsx


### PR DESCRIPTION
Update Counter project to v2.0.0 RC1.  Additionally:
1. Include pip install of excel renderer needed by Counter
2. Update python3-saml to v1.11.  This was not needed by Counter v2.  It was in response to the new SSO.