### PR TITLE
Bump Celery from v4 to v5 and bump Celery Image to latest

### DIFF
--- a/cybercom_queue/celery_queue.py
+++ b/cybercom_queue/celery_queue.py
@@ -1,17 +1,16 @@
-from celery.result import AsyncResult
 import math
 import re
-import pickle
+import pickle  #nosec
 import collections
 import json
-import celery
 from pymongo import MongoClient, DESCENDING
 from rest_framework.reverse import reverse
 from collections import OrderedDict
 from datetime import datetime
-
-from celery.task.control import inspect
+from celery import Celery
 from api import config
+
+app = Celery()
 
 class celeryConfig:
     BROKER_URL = config.BROKER_URL
@@ -44,18 +43,16 @@ class QueueTask():
         self.collection = log_collection
         self.tomb_collection = tomb_collection
         self.memcache=memcache
-        celery.Celery().config_from_object(celeryConfig)
-        self.i = inspect()
+        app.config_from_object(celeryConfig)
+        self.i = app.control.inspect()
         
     def run(self, task, task_args, task_kwargs, task_queue, user_info, tags):
         """ 
         Submit task to celerey async tasks
         """
-        # print(celeryConfig)
-        #app = Celery().config_from_object(celeryConfig)
         print(user_info)
         # Submit task
-        task_obj = celery.current_app.send_task(
+        task_obj = app.send_task(
             task, args=task_args, kwargs=task_kwargs, queue=task_queue, track_started=True,headers={"authenticated_user":user_info})
         task_log = {
             'task_id': task_obj.task_id,
@@ -90,7 +87,7 @@ class QueueTask():
             result = [item for item in col.find({'_id': task_id})]
             if len(result) == 0:
                 try:
-                    res = celery.result.AsyncResult(task_id)
+                    res = app.AsyncResult(task_id)
                     return {"status": "%s" % (res.status), "task_id": "%s" % (task_id)}
                 except:
                     raise

--- a/dc_config/cybercom_config.env
+++ b/dc_config/cybercom_config.env
@@ -1,6 +1,11 @@
 # API SETTINGS
 APPLICATION_TITLE=Cybercommons
 
+# CELERY MONGO DB and Colection - Stores the task history and the tombstone result for all tasks.
+MONGO_DB=cybercom
+MONGO_TOMBSTONE_COLLECTION=tombstone
+MONGO_LOG_COLLECTION=task_log
+
 # MONGO USER AND PASSWORD for mongodb connection
 MONGO_USERNAME=quser
 MONGO_PASSWORD=RJAkDsP7UkW9
@@ -13,21 +18,17 @@ RABBITMQ_DEFAULT_VHOST=vhost
 # Celery IMPORTS and SOURCE is a comma delimited string
 # SOURCE must be a python package with setup.py configured with dependencies managed
 CELERY_IMPORTS=cybercomq
-CELERY_SOURCE=git+https://github.com/cybercommons/cybercomq
+CELERY_SOURCE=git+https://github.com/cybercommons/cybercomq@celery5
 CELERY_QUEUE=celery
 
 # Celery and API LOG_LEVEL (DEBUG, INFO, WARNING, ERROR, or CRITICAL)
 LOG_LEVEL=INFO
-
-# CELERY MONGO DB and Colection - Stores the task history and the tombstone result for all tasks.
-MONGO_DB=cybercom
-MONGO_TOMBSTONE_COLLECTION=tombstone
-MONGO_LOG_COLLECTION=task_log
+DJANGO_LOG_LEVEL=INFO
 
 #### Change of variables below requires knowledge of Cybercom and Docker Compose Volumes #### 
-RABBITMQ_SSL_CERTFILE=/ssl/server/cert.pem
-RABBITMQ_SSL_KEYFILE=/ssl/server/key.pem
-RABBITMQ_SSL_CACERTFILE=/ssl/testca/cacert.pem
+RABBITMQ_SSL_CERT_FILE=/ssl/server/cert.pem
+RABBITMQ_SSL_KEY_FILE=/ssl/server/key.pem
+RABBITMQ_SSL_CA_FILE=/ssl/testca/cacert.pem
 BROKER_USE_SSL=true
 SSL_PATH=/ssl
 

--- a/dc_config/images/celery/celeryconfig.py
+++ b/dc_config/images/celery/celeryconfig.py
@@ -1,11 +1,15 @@
 import os
-import sys
 import ssl
+
+# CUBL: Enable logging
+import sys
 import logging
 from celery.signals import after_setup_logger
 
+# Refer to Celery's configuration documentation for details on these settings.
+# https://docs.celeryproject.org/en/stable/userguide/configuration.html
 
-def setBrookerSSL():
+def setBrokerSSL():
     if os.environ.get('BROKER_USE_SSL'):
         return {'keyfile': '/ssl/client/key.pem',
                 'certfile': '/ssl/client/cert.pem',
@@ -14,33 +18,28 @@ def setBrookerSSL():
     else:
         return None
 
-
 # SETUP BROOKER URI
 RABBITMQ_DEFAULT_USER = os.environ.get('RABBITMQ_DEFAULT_USER')
 RABBITMQ_DEFAULT_PASS = os.environ.get('RABBITMQ_DEFAULT_PASS')
 RABBITMQ_DEFAULT_VHOST = os.environ.get('RABBITMQ_DEFAULT_VHOST')
-BROKER_URL = "amqp://{0}:{1}@cybercom-rabbitmq:5671/{2}"
-BROKER_URL = BROKER_URL.format(
-    RABBITMQ_DEFAULT_USER, RABBITMQ_DEFAULT_PASS, RABBITMQ_DEFAULT_VHOST)
-BROKER_USE_SSL = setBrookerSSL()
-CELERY_SEND_EVENTS = True
-CELERY_TASK_RESULT_EXPIRES = None
-CELERY_ACCEPT_CONTENT = ['json']
+broker_url = f"amqp://{RABBITMQ_DEFAULT_USER}:{RABBITMQ_DEFAULT_PASS}@cybercom-rabbitmq:5671/{RABBITMQ_DEFAULT_VHOST}"
+broker_use_ssl = setBrokerSSL()
+worker_send_task_events = True
+result_expires = None
+accept_content = ['json']
 
 # SETUP MONGO URI
 SSL_PATH = os.environ.get('SSL_PATH')
 MONGO_USERNAME = os.environ.get('MONGO_USERNAME')
 MONGO_PASSWORD = os.environ.get('MONGO_PASSWORD')
-MONGO_URI = "mongodb://{0}:{1}@cybercom-mongo:27017/?ssl=true&ssl_ca_certs={2}/testca/cacert.pem&ssl_certfile={2}/client/mongodb.pem"
-CELERY_RESULT_BACKEND = MONGO_URI.format(
-    MONGO_USERNAME, MONGO_PASSWORD, SSL_PATH)
+result_backend = f"mongodb://{MONGO_USERNAME}:{MONGO_PASSWORD}@cybercom-mongo:27017/?ssl=true&ssl_ca_certs={SSL_PATH}/testca/cacert.pem&ssl_certfile={SSL_PATH}/client/mongodb.pem"
 
-CELERY_MONGODB_BACKEND_SETTINGS = {
+mongodb_backend_settings = {
     "database": os.environ.get('MONGO_DB', "cybercom"),
     "taskmeta_collection": os.environ.get('MONGO_TOMBSTONE_COLLECTION', "tombstone")
 }
 
-CELERY_IMPORTS = tuple(os.environ.get('CELERY_IMPORTS').split(','))
+imports = tuple(os.environ.get('CELERY_IMPORTS').split(','))
 
 
 @after_setup_logger.connect

--- a/dc_config/images/celery/dockerfile
+++ b/dc_config/images/celery/dockerfile
@@ -1,37 +1,45 @@
-FROM python:3.8
-#6-alpine3.9 
-#culibraries/celery:1.0.4
-# python:3.6-alpine3.9
+ARG DOCKER_PYTHON_VERSION=3.10-slim-bookworm
+FROM python:$DOCKER_PYTHON_VERSION
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONUNBUFFERED=1 
 
-RUN apt update
-# RUN RUN apt-get update && apt-get install -y \
-#     git \
-#     imagemagick \
-#     libimage-exiftool-perl \
-#     libtiff-dev \
-#     libxml2-dev \
-#     libxslt-dev \
-#     libopenjp2-7 
-# mariadb-server
-RUN apt install -y  git tzdata vim python3-pil python3-pil.imagetk
-RUN apt install -y default-libmysqlclient-dev
-# RUN apk add build-base libressl libffi-dev libressl-dev libxslt-dev libxml2-dev xmlsec-dev xmlsec
-# RUN apk add mariadb-dev git tzdata
+# CUBL Specific OS-level packages:
+# Besides the standard libs, the following are needed:
+#   thumbnailq requires Magick Wand and Pillow for image processing. 
+#   counterq requires mysql client which relies on pkg-config.
+RUN apt-get update && apt-get install -y \
+    git \
+    tzdata \
+    vim \
+    gcc \
+    pkg-config \
+    libmagickwand-dev \ 
+    python3-pil python3-pil.imagetk \
+    default-libmysqlclient-dev \
+  # Clean up apt cache to keep the layer small
+  && rm -rf /var/lib/apt/lists/*
+
+# Original Cybercommons installs
+# RUN apt-get install -y imagemagick libimage-exiftool-perl libtiff-dev libxml2-dev libxslt-dev libopenjp2-7 
+
+# Set timezone
 RUN cp /usr/share/zoneinfo/America/Denver /etc/localtime
 
-WORKDIR /  
-COPY requirements.txt ./  
-RUN pip install --no-cache-dir -r requirements.txt  
-RUN rm requirements.txt  
+# Upgrade pip, setuptools, and wheel early for better build compatibility
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 
+WORKDIR /
+COPY requirements.txt ./  
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt \
+  && rm requirements.txt  
 
 COPY . /app  
 WORKDIR /app
 
-#Setup Celery User
-#Setup Celery User
+# Setup Celery User
+# -r: system user, -U: create a group with the same name, -m: create home directory
 RUN useradd -r -U -m celery \
   && chown celery:celery -R /app
 

--- a/dc_config/images/celery/requirements.txt
+++ b/dc_config/images/celery/requirements.txt
@@ -1,4 +1,3 @@
-celery==4.4.7
-kombu==4.6.11
-pymongo==3.11.0
-
+celery==5.2.7
+kombu==5.5.4
+pymongo==3.12.3

--- a/dc_config/images/celery/startCeleryWorker
+++ b/dc_config/images/celery/startCeleryWorker
@@ -7,11 +7,8 @@ from celeryconfig import *
 for itm in os.environ.get("CELERY_SOURCE").split(','):
     call(['pip3','install',itm])
 
-call(['pip3','install','Pillow'])
-
 celery_queue=os.environ.get("CELERY_QUEUE","celery")
 log_level=os.environ.get("LOG_LEVEL","INFO")
 
 call(["su", "-p", "celery", "-c",
-  "celery -Q {0} -l {1} worker".format(celery_queue, log_level)])
-#call(["celery", "worker", "-Q", celery_queue, "-l", log_level])
+  "celery worker -Q {0} -l {1}".format(celery_queue, log_level)])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-amqp==2.6.1
+amqp==5.3.1
 arkpy==0.6
 billiard==3.6.4.0
 boto3==1.18.26
-botocore==1.21.26
-celery==4.4.7
+celery==5.2.7
 certifi==2021.5.30
 charset-normalizer==2.0.4
 defusedxml==0.5.0
@@ -22,7 +21,7 @@ gunicorn==19.9.0
 idna==3.2
 isodate==0.6.0
 jmespath==0.10.0
-kombu==4.6.11
+kombu==5.5.4
 lxml==4.6.3
 mysql==0.0.3
 PyJWT==1.7.1
@@ -30,12 +29,11 @@ pymongo==3.7.2
 python-dateutil==2.8.2
 python-memcached==1.59
 python3-saml==1.11.0
-pytz==2021.1
+pytz==2025.2
 PyYAML==6.0.1
 requests==2.26.0
-s3transfer==0.5.0
 six==1.12.0
 sqlparse==0.3.0
 urllib3==1.26.6
-vine==1.3.0
+vine==5.1.0
 xmlsec==1.3.11


### PR DESCRIPTION
# PR Title  
Update Cybercoms Celery Image to Latest Versions  

## Summary  
This PR updates the **Cybercoms Celery image** to use the latest supported OS, Python, and Celery versions.  
The **Cybercom API image itself is not upgraded**, but minor changes were applied to maintain compatibility with the updated Celery image.  

## Change Log  
1. **Base OS for Celery**: Upgraded to Debian 12 (Bookworm).  
2. **Python for Celery**: Upgraded base image to Python 3.10.  
3. **Celery**: Upgraded to Celery 5.x.  

## Cybercom API Compatibility Adjustments  
- Updated **child package versions in Cybercom API's `requirements.txt`** to support Celery v5.  
- No Cybercom API base image upgrade was performed.  
- Adjustments are limited to ensuring API <-> Celery communication and task execution continue to function as expected.

## Breaking Changes  
- Celery 5 introduces **API-level changes** that may require updates to existing Celery task code.  
- Affected areas include:  
  - IR report tasks  
  - Email tasks  
  - Geo tasks  
  - Thumbnail generation tasks
- Task maintainers should review Celery v5 API changes and update their code accordingly.  

## Notes  
- The Celery 4 → 5 upgrade required bumping versions of several dependent packages.  
- These changes are consistent with those in Cybercommons commit `331e7b7` (dated 2021-06-18).  
