### PR TITLE
Allow internal cluster traffic to reach API

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -60,6 +60,9 @@ SECRET_KEY = os.getenv('DJANGO_SECRET_KEY',
 DEBUG = True if os.getenv('API_DEBUG') == 'True' else False
 
 ALLOWED_HOSTS = ['.colorado.edu']
+extra_hosts = os.getenv('EXTRA_ALLOWED_HOSTS', '')
+if extra_hosts:
+    ALLOWED_HOSTS.extend([host.strip() for host in extra_hosts.split(',')])
 
 CORS_ORIGIN_WHITELIST = (
     'https://libapps.colorado.edu',


### PR DESCRIPTION
## Summary
Update ALLOWED_HOSTS to take in comma-separated values from environment variable `EXTRA_ALLOWED_HOSTS`.  Deployments can set `EXTRA_ALLOWED_HOSTS` to the cluster internal service URL to allow internal cluster traffic to reach Cybercom API.

## Context & Problem
We have internal applications in our EKS cluster that need to call the Cybercom API (Django). Currently, Django's `ALLOWED_HOSTS` setting is hard-coded to only accept `.colorado.edu` traffic. 

When an internal app calls the API via the cluster-internal service URL (`http://cybercom-api.cybercom2.svc.cluster.local:8080`), Django rejects the request with an error because the internal host header is not recognized as a secure/allowed domain. 

## Solution
Instead of hardcoding Kubernetes-specific infrastructure paths into our Cybercom Django codebase, we use the environment variable `EXTRA_ALLOWED_HOSTS` which can be set to include the cluster service endpoint URL.

*Note: Django automatically strips port numbers (like `:8080`) during host validation, so providing the base domain string is sufficient.*

## Notes
- No breaking changes expected
- This change corresponds directly with the upcoming [infrastructure PR](https://github.com/CUB-Libraries-CTA/aws-eks-deployment/pull/12)  to update the Kubernetes deployment YAML with the new environment variable.